### PR TITLE
Use 'MD5.Create' instead of 'new MD5CryptoServiceProvider'.

### DIFF
--- a/MonoTouch.Dialog/Utilities/ImageLoader.cs
+++ b/MonoTouch.Dialog/Utilities/ImageLoader.cs
@@ -87,7 +87,7 @@ namespace MonoTouch.Dialog.Utilities
 		
 		static NSString nsDispatcher = new NSString ("x");
 		
-		static MD5CryptoServiceProvider checksum = new MD5CryptoServiceProvider ();
+		static MD5 checksum = MD5.Create ();
 		
 		/// <summary>
 		///    This contains the default loader which is configured to be 50 images


### PR DESCRIPTION
Fixes this compiler warning:

> warning SYSLIB0021: 'MD5CryptoServiceProvider' is obsolete: 'Derived cryptographic types are obsolete. Use the Create method on the base type instead.' (https://aka.ms/dotnet-warnings/SYSLIB0021)